### PR TITLE
export_include_dirs header files

### DIFF
--- a/src/Android.bp
+++ b/src/Android.bp
@@ -86,7 +86,8 @@ cc_library {
         "lxc/terminal.c",
         "lxc/utils.c"
     ],
-    shared_libs: ["libcap"]
+    shared_libs: ["libcap"],
+    export_include_dirs : ["."],
 }
 
 cc_binary {


### PR DESCRIPTION
export_include_dirs header files to use lxccontainer.h in other module