### PR TITLE
Enable lxc-checkconfig

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -28,6 +28,7 @@ phony {
         "lxc-create",
         "lxc-snapshot",
         "lxc-checkpoint",
+        "lxc-checkconfig",
         "init.lxc",
         "lxc-monitord",
         "lxc-user-nic",

--- a/src/Android.bp
+++ b/src/Android.bp
@@ -370,3 +370,9 @@ cc_binary {
         "lxc/utils.c"
     ]
 }
+
+sh_binary {
+    name: "lxc-checkconfig",
+    src: "lxc/cmd/lxc-checkconfig.in",
+    vendor: true,
+}


### PR DESCRIPTION
Enable lxc-checkconfig to check kernel support lxc